### PR TITLE
Commented out line 90 to prevent plugin activation issue in Joomla 5

### DIFF
--- a/script.php
+++ b/script.php
@@ -87,7 +87,7 @@ return new class () implements ServiceProviderInterface {
 			 */
 			public function install(InstallerAdapter $adapter): bool
 			{
-				$this->enablePlugin($adapter);
+				// $this->enablePlugin($adapter);
 
 				return true;
 			}


### PR DESCRIPTION
This update comments out line 90 in the plg_wtjshoppingswjprojects plugin code to resolve a compatibility issue with Joomla 5, which prevents the plugin from being activated correctly. Without this change, the plugin causes issues that prevent accessing and managing its settings.

The fix ensures the plugin operates smoothly in Joomla 5 environments, preventing the activation bug. Please review the changes and consider merging them into the main repository.